### PR TITLE
Fix error logging on unknown account getNonce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telosnetwork/telosevm-js",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Telos EVM JS SDK",
   "keywords": [],
   "main": "lib/cjs/telosevm-js.js",

--- a/src/telos.ts
+++ b/src/telos.ts
@@ -579,8 +579,9 @@ export class TelosApi {
    * @param address The ETH address in contract
    *
    * @returns {Promise<Account>} Account row associated with address
+   * or undefined if there is no account matching the address.
    */
-  async getEthAccount(address: string): Promise<Account> {
+  async getEthAccount(address: string): Promise<Account | undefined> {
     if (!address) throw new Error('No address provided')
     if (address.startsWith('0x')) address = address.substring(2)
 
@@ -601,7 +602,7 @@ export class TelosApi {
     if (rows.length && rows[0].address === address) {
       return transformEthAccount(rows[0])
     } else {
-      throw new Error(`Account with address ${address} not found`)
+      return undefined
     }
   }
 
@@ -624,13 +625,12 @@ export class TelosApi {
   async getNonce(address: any) {
     if (!address) return '0x0'
 
-    try {
-      const account = await this.getEthAccount(address)
-      return `0x${account.nonce.toString(16)}`
-    } catch (e) {
-      console.log(e)
-      return '0x0'
-    }
+    const account = await this.getEthAccount(address)
+
+    if (!account)
+        return '0x0'
+
+    return `0x${account.nonce.toString(16)}`
   }
 
   /**
@@ -648,10 +648,13 @@ export class TelosApi {
     if (key && key.startsWith('0x')) key = key.substring(2)
     const paddedKey = '0'.repeat(64 - key.length) + key
 
-    const { index } = await this.getEthAccount(address)
+    const acc = await this.getEthAccount(address)
+    if (!acc)
+        return '0x0';
+
     const { rows } = await this.getTable({
       code: this.telosContract,
-      scope: index,
+      scope: acc.index,
       table: 'accountstate',
       key_type: 'sha256',
       index_position: 2,


### PR DESCRIPTION
We were printing a big traceback on each query to the RPC when an address didn't have a matching account on the contract table.

Closes #13 
